### PR TITLE
Replace klpbbs.com with klpbbs.us

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,23 +31,23 @@ If you encounter any problems in using the project, you can [submit an Issue](ht
 
 - **zrll_** Front-end, Back-end, Test
     - [GitHub](https://github.com/zrll12)
-    - [KLPBBS](https://klpbbs.com/?922084)
+    - [KLPBBS](https://klpbbs.us/?922084)
 
 - **Snowball_233** Front-end, CI/CD, Ops, Doc
     - [GitHub](https://github.com/SnowballXueQiu)
-    - [KLPBBS](https://klpbbs.com/?1082463)
+    - [KLPBBS](https://klpbbs.us/?1082463)
 
 - **M397749490** CI/CD, Ops
     - [GitHub](https://github.com/M397749490)
-    - [KLPBBS](https://klpbbs.com/?32980)
+    - [KLPBBS](https://klpbbs.us/?32980)
 
 - **damesck** Front-end, Doc
     - [GitHub](https://github.com/damesck233)
-    - [KLPBBS](https://klpbbs.com/?6173)
+    - [KLPBBS](https://klpbbs.us/?6173)
 
 - **GaoNeng-wWw** Front-end
     - [GitHub](https://github.com/GaoNeng-wWw)
 
 - **klpz** API Provide
     - [GitHub](https://github.com/klpbbs)
-    - [KLPBBS](https://klpbbs.com/?1)
+    - [KLPBBS](https://klpbbs.us/?1)

--- a/README_CN.md
+++ b/README_CN.md
@@ -31,23 +31,23 @@
 
 - **zrll_** 前端, 后端, 测试
 	- [GitHub](https://github.com/zrll12)
-	- [苦力怕论坛](https://klpbbs.com/?922084)
+	- [苦力怕论坛](https://klpbbs.us/?922084)
 
 - **Snowball_233** 前端, CI/CD, 运维, 文档
 	- [GitHub](https://github.com/SnowballXueQiu)
-	- [苦力怕论坛](https://klpbbs.com/?1082463)
+	- [苦力怕论坛](https://klpbbs.us/?1082463)
 
 - **M397749490** CI/CD, 运维
 	- [GitHub](https://github.com/M397749490)
-	- [苦力怕论坛](https://klpbbs.com/?32980)
+	- [苦力怕论坛](https://klpbbs.us/?32980)
 
 - **damesck** 前端, 文档
 	- [GitHub](https://github.com/damesck233)
-	- [苦力怕论坛](https://klpbbs.com/?6173)
+	- [苦力怕论坛](https://klpbbs.us/?6173)
 
 - **GaoNeng-wWw** 前端
 	- [GitHub](https://github.com/GaoNeng-wWw)
 
 - **苦力怕纸** API提供
     - [GitHub](https://github.com/klpbbs)
-    - [苦力怕论坛](https://klpbbs.com/?1)
+    - [苦力怕论坛](https://klpbbs.us/?1)

--- a/app/(root)/about/data/developers.json
+++ b/app/(root)/about/data/developers.json
@@ -9,7 +9,7 @@
       },
       {
         "name": "苦力怕论坛",
-        "url": "https://klpbbs.com/?922084"
+        "url": "https://klpbbs.us/?922084"
       }
     ],
     "logo": "https://avatars.githubusercontent.com/u/46812903"
@@ -24,7 +24,7 @@
       },
       {
         "name": "苦力怕论坛",
-        "url": "https://klpbbs.com/?1082463"
+        "url": "https://klpbbs.us/?1082463"
       }
     ],
     "logo": "https://avatars.githubusercontent.com/u/97330394"
@@ -39,10 +39,10 @@
       },
       {
         "name": "苦力怕论坛",
-        "url": "https://klpbbs.com/?32980"
+        "url": "https://klpbbs.us/?32980"
       }
     ],
-    "logo": "https://user.klpbbs.com/data/avatar/000/03/29/80_avatar_big.jpg"
+    "logo": "https://user.klpbbs.us/data/avatar/000/03/29/80_avatar_big.jpg"
   },
   {
     "name": "damesck",
@@ -54,10 +54,10 @@
       },
       {
         "name": "苦力怕论坛",
-        "url": "https://klpbbs.com/?6173"
+        "url": "https://klpbbs.us/?6173"
       }
     ],
-    "logo": "https://user.klpbbs.com/data/avatar/000/00/61/73_avatar_big.jpg"
+    "logo": "https://user.klpbbs.us/data/avatar/000/00/61/73_avatar_big.jpg"
   },
   {
     "name": "GaoNeng-wWw",
@@ -80,9 +80,9 @@
       },
       {
         "name": "苦力怕论坛",
-        "url": "https://klpbbs.com/?1"
+        "url": "https://klpbbs.us/?1"
       }
     ],
-    "logo": "https://user.klpbbs.com/data/avatar/000/00/00/01_avatar_big.jpg"
+    "logo": "https://user.klpbbs.us/data/avatar/000/00/00/01_avatar_big.jpg"
   }
 ]

--- a/app/(root)/about/data/examiners.json
+++ b/app/(root)/about/data/examiners.json
@@ -5,10 +5,10 @@
     "links": [
       {
         "name": "苦力怕论坛",
-        "url": "https://klpbbs.com/?158683"
+        "url": "https://klpbbs.us/?158683"
       }
     ],
-    "logo": "https://user.klpbbs.com/data/avatar/000/15/86/83_avatar_big.jpg"
+    "logo": "https://user.klpbbs.us/data/avatar/000/15/86/83_avatar_big.jpg"
   },
   {
     "name": "水稻本尊",
@@ -16,9 +16,9 @@
     "links": [
       {
         "name": "苦力怕论坛",
-        "url": "https://klpbbs.com/?14351"
+        "url": "https://klpbbs.us/?14351"
       }
     ],
-    "logo": "https://user.klpbbs.com/data/avatar/000/01/43/51_avatar_big.jpg"
+    "logo": "https://user.klpbbs.us/data/avatar/000/01/43/51_avatar_big.jpg"
   }
 ]

--- a/app/(root)/about/data/organizations.json
+++ b/app/(root)/about/data/organizations.json
@@ -16,9 +16,9 @@
     "links": [
       {
         "name": "官方网站",
-        "url": "https://klpbbs.com/"
+        "url": "https://klpbbs.us/"
       }
     ],
-    "logo": "https://klpbbs.com/favicon.ico"
+    "logo": "https://klpbbs.us/favicon.ico"
   }
 ]

--- a/app/(root)/backstage/judge/[answerId]/page.tsx
+++ b/app/(root)/backstage/judge/[answerId]/page.tsx
@@ -204,7 +204,7 @@ export default function JudgeSinglePage({ params }: { params: { answerId: number
                 填写用户:&nbsp;
                 <Text
                   component="a"
-                  href={`https://klpbbs.com/?${answer?.user}`}
+                  href={`https://klpbbs.us/?${answer?.user}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   c="blue"

--- a/app/(root)/oauth/callback/components/UserInfoCard.tsx
+++ b/app/(root)/oauth/callback/components/UserInfoCard.tsx
@@ -6,7 +6,7 @@ import { Cookie } from '@/components/cookie';
 export default function UserInfoCard(props: UserInfoCardProps) {
     const router = useRouter();
     const id_str = props.uid.padStart(9, '0');
-    const avatar_url = `https://user.klpbbs.com/data/avatar/${id_str.substring(0, 3)}/${id_str.substring(3, 5)}/${id_str.substring(5, 7)}/${id_str.substring(7, 9)}_avatar_big.jpg`;
+    const avatar_url = `https://user.klpbbs.us/data/avatar/${id_str.substring(0, 3)}/${id_str.substring(3, 5)}/${id_str.substring(5, 7)}/${id_str.substring(7, 9)}_avatar_big.jpg`;
 
     function logOut() {
         Cookie.clearAllCookies();

--- a/app/(root)/oauth/components/LoginBanner.tsx
+++ b/app/(root)/oauth/components/LoginBanner.tsx
@@ -12,12 +12,12 @@ export function LoginBanner() {
     setLoading(true);
 
     window.location.href =
-      'https://klpbbs.com/plugin.php?id=klpbbs_api:oauth2&appid=4474a21e0077bcd413dd975e5c9aacc339e1fd54&state=123';
+      'https://klpbbs.us/plugin.php?id=klpbbs_api:oauth2&appid=4474a21e0077bcd413dd975e5c9aacc339e1fd54&state=123';
 
     // UserApi.getToken()
     //     .then(result => {
     //         Cookie.setCookie('token', result, 7);
-    //         window.location.href = `https://klpbbs.com/plugin.php?id=klpbbs_api:oauth2&appid=4474a21e0077bcd413dd975e5c9aacc339e1fd54&state=${result}`;
+    //         window.location.href = `https://klpbbs.us/plugin.php?id=klpbbs_api:oauth2&appid=4474a21e0077bcd413dd975e5c9aacc339e1fd54&state=${result}`;
     //     });
   }
 

--- a/app/(root)/tos/page.tsx
+++ b/app/(root)/tos/page.tsx
@@ -38,7 +38,7 @@ export default function TosPage() {
         </Title>
         <Title
           order={3}
-          onClick={() => window.open('https://klpbbs.com/thread-65605-1-1.html', '_blank')}
+          onClick={() => window.open('https://klpbbs.us/thread-65605-1-1.html', '_blank')}
           style={{ cursor: 'pointer' }}
         >
           苦力怕论坛总坛规

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -18,31 +18,31 @@ export default function Footer() {
                 </a>
                 &nbsp;|&nbsp;
                 <a
-                  href="https://klpbbs.com"
+                  href="https://klpbbs.us"
                   target="_blank"
                   rel="noreferrer"
                   style={{ textDecoration: 'none' }}
                 >
                     苦力怕论坛
                 </a>
-                &nbsp;|&nbsp;
-                <a
-                  href="https://beian.miit.gov.cn/"
-                  target="_blank"
-                  rel="noreferrer"
-                  style={{ textDecoration: 'none', color: 'black' }}
-                >
-                    粤ICP备2023071842号-3
-                </a>
-                &nbsp;|&nbsp;
-                <a
-                  href="http://www.beian.gov.cn/portal/registerSystemInfo?recordcode=44200002445329"
-                  target="_blank"
-                  rel="noreferrer"
-                  style={{ textDecoration: 'none', color: 'black' }}
-                >
-                    <img src="https://data.klpbbs.com/file/tc/img/2022/11/12/636f24d117464.png" /> 粤公网安备 44200002445329号
-                </a>
+                // &nbsp;|&nbsp;
+                // <a
+                //   href="https://beian.miit.gov.cn/"
+                //   target="_blank"
+                //   rel="noreferrer"
+                //   style={{ textDecoration: 'none', color: 'black' }}
+                // >
+                //     粤ICP备2023071842号-3
+                // </a>
+                // &nbsp;|&nbsp;
+                // <a
+                //   href="http://www.beian.gov.cn/portal/registerSystemInfo?recordcode=44200002445329"
+                //   target="_blank"
+                //   rel="noreferrer"
+                //   style={{ textDecoration: 'none', color: 'black' }}
+                // >
+                //     <img src="https://data.klpbbs.com/file/tc/img/2022/11/12/636f24d117464.png" /> 粤公网安备 44200002445329号
+                // </a>
             </p>
         </Container>
     );

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -15,7 +15,7 @@ interface Link {
 
 const links: Link[] = [
     { link: '/', label: '首页' },
-    { link: 'https://klpbbs.com', label: '主站' },
+    { link: 'https://klpbbs.us', label: '主站' },
     { link: '/about', label: '关于' },
     { link: '/tos', label: '条款' },
 ];

--- a/components/NavbarList.tsx
+++ b/components/NavbarList.tsx
@@ -12,7 +12,7 @@ interface Link {
 
 const links: Link[] = [
     { link: '/', label: '首页' },
-    { link: 'https://klpbbs.com', label: '主站' },
+    { link: 'https://klpbbs.us', label: '主站' },
     { link: '/about', label: '关于' },
     { link: '/tos', label: '条款' },
 ];


### PR DESCRIPTION
Migrate external links and asset hosts from klpbbs.com to klpbbs.us across the project: README/README_CN, about data (developers/examiners/organizations), OAuth (login and avatar URLs), TOS, judge page, and navigation/header/footer components. Also updated avatar/logo URLs to the .us host and commented out the ICP/Beian badge links in Footer.