### PR TITLE
Use klpbbs.com domain for avatar URLs

### DIFF
--- a/app/(root)/about/data/developers.json
+++ b/app/(root)/about/data/developers.json
@@ -42,7 +42,7 @@
         "url": "https://klpbbs.us/?32980"
       }
     ],
-    "logo": "https://user.klpbbs.us/data/avatar/000/03/29/80_avatar_big.jpg"
+    "logo": "https://user.klpbbs.com/data/avatar/000/03/29/80_avatar_big.jpg"
   },
   {
     "name": "damesck",
@@ -57,7 +57,7 @@
         "url": "https://klpbbs.us/?6173"
       }
     ],
-    "logo": "https://user.klpbbs.us/data/avatar/000/00/61/73_avatar_big.jpg"
+    "logo": "https://user.klpbbs.com/data/avatar/000/00/61/73_avatar_big.jpg"
   },
   {
     "name": "GaoNeng-wWw",
@@ -83,6 +83,6 @@
         "url": "https://klpbbs.us/?1"
       }
     ],
-    "logo": "https://user.klpbbs.us/data/avatar/000/00/00/01_avatar_big.jpg"
+    "logo": "https://user.klpbbs.com/data/avatar/000/00/00/01_avatar_big.jpg"
   }
 ]

--- a/app/(root)/about/data/examiners.json
+++ b/app/(root)/about/data/examiners.json
@@ -8,7 +8,7 @@
         "url": "https://klpbbs.us/?158683"
       }
     ],
-    "logo": "https://user.klpbbs.us/data/avatar/000/15/86/83_avatar_big.jpg"
+    "logo": "https://user.klpbbs.com/data/avatar/000/15/86/83_avatar_big.jpg"
   },
   {
     "name": "水稻本尊",
@@ -19,6 +19,6 @@
         "url": "https://klpbbs.us/?14351"
       }
     ],
-    "logo": "https://user.klpbbs.us/data/avatar/000/01/43/51_avatar_big.jpg"
+    "logo": "https://user.klpbbs.com/data/avatar/000/01/43/51_avatar_big.jpg"
   }
 ]

--- a/app/(root)/oauth/callback/components/UserInfoCard.tsx
+++ b/app/(root)/oauth/callback/components/UserInfoCard.tsx
@@ -6,7 +6,7 @@ import { Cookie } from '@/components/cookie';
 export default function UserInfoCard(props: UserInfoCardProps) {
     const router = useRouter();
     const id_str = props.uid.padStart(9, '0');
-    const avatar_url = `https://user.klpbbs.us/data/avatar/${id_str.substring(0, 3)}/${id_str.substring(3, 5)}/${id_str.substring(5, 7)}/${id_str.substring(7, 9)}_avatar_big.jpg`;
+    const avatar_url = `https://user.klpbbs.com/data/avatar/${id_str.substring(0, 3)}/${id_str.substring(3, 5)}/${id_str.substring(5, 7)}/${id_str.substring(7, 9)}_avatar_big.jpg`;
 
     function logOut() {
         Cookie.clearAllCookies();


### PR DESCRIPTION
Replace klpbbs.us with klpbbs.com for avatar image URLs across the app. Updated app/(root)/about/data/developers.json, app/(root)/about/data/examiners.json, and app/(root)/oauth/callback/components/UserInfoCard.tsx so user/avatar links reference the .com host.